### PR TITLE
v3.0.0 - Use Brewfile instead of shell scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.0.0 (TODO)
+
+* Replaces `restore-packages.sh` and `restore-casks.sh` with a single `Brewfile` which also now includes `taps`
+
 ## v2.2.1 (2021-04-09)
 
 * Fixes a bug where we left a mocked directory on disk (closes #6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## v3.0.0 (TODO)
+## v3.0.0 (2021-05-04)
 
-* Replaces `restore-packages.sh` and `restore-casks.sh` with a single `Brewfile` which also now includes `taps`
+* Replaces `restore-brew-packages.sh` and `restore-brew-casks.sh` with a single `Brewfile` which also now includes all installed `taps`
+* Adds `--force` flag to force Brew backups even if errors are present in `brew doctor`
 
 ## v2.2.1 (2021-04-09)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Alchemist can backup your entire Homebrew (macOS and Linux) or Chocolatey (Windo
 alchemist --backup
 ```
 
+If you run into troubles backing up your Homebrew instance, it's recommended to try running Alcehmist with the `--update` flag first.
+
 ## Alchemist Update
 
 **macOS and Linux**
@@ -78,6 +80,8 @@ Options:
         Backup your Homebrew instance.
     --update
         Update your Homebrew instance.
+    --force
+        Forces actions such as backing up even when there are errors. (Brew only)
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Update, backup, and administer your Homebrew or Chocolatey instance.
 
 ## Alchemist Backup
 
-Alchemist can backup your entire Homebrew (macOS and Linux) or Chocolatey (Windows) instance. It does this by retrieving the list of Homebrew packages and casks and creating shell scripts that can be run to restore your entire Homebrew instance.
+Alchemist can backup your entire Homebrew (macOS and Linux) or Chocolatey (Windows) instance. It does this by retrieving the list of installed packages and creating a script that can be run to restore your entire Homebrew or Chocolatey instance.
 
 ```bash
 alchemist --backup
@@ -37,7 +37,7 @@ Alchemist automates the entire Homebrew update process including:
 
 **Windows**
 
-Alchemist will update all of your packages:
+Alchemist will update all of your Chocolatey packages:
 
 ```bash
 alchemist --update
@@ -67,16 +67,16 @@ Alchemist saves logs to `~/alchemist/update/alchemist-update.log`. Logs by defau
 
 **Restore Scripts**
 
-Scripts generated from the backup functionality of Alchemist live at `~/alchemist/backup/restore-brew-package.sh`. Simply make the script executable and run it to reinstall all of your brew packages (eg: `./restore-brew-package.sh`).
+Scripts generated from the backup functionality of Alchemist live at `~/alchemist/backup`. Simply run `brew bundle --file path/to/Brewfile` or `path/to/restore-choco-packages.bat` file to restore your packages.
 
 ```
 Usage:
     alchemist --update
 
 Options:
-    -backup
+    --backup
         Backup your Homebrew instance.
-    -update
+    --update
         Update your Homebrew instance.
 ```
 

--- a/main.go
+++ b/main.go
@@ -30,13 +30,14 @@ func main() {
 	} else {
 		brewUpdate := flag.Bool("update", false, "Update your Homebrew instance.")
 		brewBackup := flag.Bool("backup", false, "Backup your Homebrew instance.")
+		force := flag.Bool("force", false, "Forces actions such as backing up even when there are errors.")
 		flag.Parse()
 
 		if *brewUpdate {
 			brew.Update()
 			return
 		} else if *brewBackup {
-			brew.Backup()
+			brew.Backup(*force)
 			return
 		}
 

--- a/src/brew/backup.go
+++ b/src/brew/backup.go
@@ -20,7 +20,7 @@ func Backup(force bool) {
 	fmt.Println("Alchemist is backing up brew...")
 
 	brewDoctor, brewDoctorErr := general.RunCommand(exec.Command, "brew", []string{"doctor"})
-	if brewDoctor != nil || force == true {
+	if brewDoctor != nil || force {
 		log.Printf("brew doctor: %s", brewDoctor)
 	} else {
 		fmt.Println("Alchemist checked with brew doctor, you need to fix your Homebrew instance before it can be backed up!")

--- a/src/brew/backup.go
+++ b/src/brew/backup.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Backup backs up your Homebrew instance
-func Backup() {
+func Backup(force bool) {
 	action := "backup"
 	alchemistBackupDir := general.SetupDir(action)
 	general.SetupLogging(alchemistBackupDir, action)
@@ -20,11 +20,11 @@ func Backup() {
 	fmt.Println("Alchemist is backing up brew...")
 
 	brewDoctor, brewDoctorErr := general.RunCommand(exec.Command, "brew", []string{"doctor"})
-	if brewDoctor != nil {
+	if brewDoctor != nil || force == true {
 		log.Printf("brew doctor: %s", brewDoctor)
 	} else {
 		fmt.Println("Alchemist checked with brew doctor, you need to fix your Homebrew instance before it can be backed up!")
-		log.Printf("brew update: %s", brewDoctorErr)
+		log.Printf("brew doctor: %s", brewDoctorErr)
 		os.Exit(1)
 	}
 
@@ -37,10 +37,8 @@ func Backup() {
 	caskList, _ := general.RunCommand(exec.Command, "brew", []string{"list", "--cask"})
 	casks := generateCaskList(caskList)
 
-	var brewfileContent []string
-	brewfileContent = append(taps)
-	brewfileContent = append(packages)
-	brewfileContent = append(casks)
+	brewfileContent := append(taps, packages...)
+	brewfileContent = append(brewfileContent, casks...)
 
 	createBrewfile(brewfileContent, alchemistBackupDir+"/Brewfile")
 

--- a/src/brew/backup_test.go
+++ b/src/brew/backup_test.go
@@ -30,7 +30,7 @@ func TestGeneratePackageList(t *testing.T) {
 
 func TestGenerateCaskList(t *testing.T) {
 	mockCaskList := bytes.NewBufferString("cask1\ncask2")
-	wanted := []string{"# Casks", "cask \"cask1\"", "cask \"cask2\""}
+	wanted := []string{"# Casks\ncask_args appdir: \"~/Applications\", require_sha: true", "cask \"cask1\"", "cask \"cask2\""}
 	output := generateCaskList(mockCaskList)
 	for i := range output {
 		if output[i] != wanted[i] {

--- a/src/brew/backup_test.go
+++ b/src/brew/backup_test.go
@@ -6,24 +6,35 @@ import (
 	"testing"
 )
 
-func TestGeneratePackageScriptCommands(t *testing.T) {
-	mockPackageList := bytes.NewBufferString("package1\npackage2")
-	wanted := []string{"#!/bin/sh", "brew install package1", "brew install package2"}
-	output := generatePackageScriptCommands(mockPackageList)
+func TestGenerateTapList(t *testing.T) {
+	mockPackageList := bytes.NewBufferString("username1/tap1\nusername2/tap2")
+	wanted := []string{"# Taps", "tap \"username1/tap1\"", "tap \"username2/tap2\""}
+	output := generateTapList(mockPackageList)
 	for i := range output {
 		if output[i] != wanted[i] {
-			t.Errorf("generatePackageScriptCommands did not properly generate a script with commands. Line %s of the script file got: %s, wanted: %s", strconv.Itoa(i), output[i], wanted[i])
+			t.Errorf("generateTapList did not properly generate a script with commands. Line %s of the script file got: %s, wanted: %s", strconv.Itoa(i), output[i], wanted[i])
 		}
 	}
 }
 
-func TestGenerateCaskScriptCommands(t *testing.T) {
-	mockCaskList := bytes.NewBufferString("cask1\ncask2")
-	wanted := []string{"#!/bin/sh", "brew install --cask cask1", "brew install --cask cask2"}
-	output := generateCaskScriptCommands(mockCaskList)
+func TestGeneratePackageList(t *testing.T) {
+	mockPackageList := bytes.NewBufferString("package1\npackage2")
+	wanted := []string{"# Packages", "brew \"package1\"", "brew \"package2\""}
+	output := generatePackageList(mockPackageList)
 	for i := range output {
 		if output[i] != wanted[i] {
-			t.Errorf("generateCaskScriptCommands did not properly generate a script with commands. Line %s of the script file got: %s, wanted: %s", strconv.Itoa(i), output[i], wanted[i])
+			t.Errorf("generatePackageList did not properly generate a script with commands. Line %s of the script file got: %s, wanted: %s", strconv.Itoa(i), output[i], wanted[i])
+		}
+	}
+}
+
+func TestGenerateCaskList(t *testing.T) {
+	mockCaskList := bytes.NewBufferString("cask1\ncask2")
+	wanted := []string{"# Casks", "cask \"cask1\"", "cask \"cask2\""}
+	output := generateCaskList(mockCaskList)
+	for i := range output {
+		if output[i] != wanted[i] {
+			t.Errorf("generateCaskList did not properly generate a script with commands. Line %s of the script file got: %s, wanted: %s", strconv.Itoa(i), output[i], wanted[i])
 		}
 	}
 }


### PR DESCRIPTION
* Replaces `restore-brew-packages.sh` and `restore-brew-casks.sh` with a single `Brewfile` which also now includes all installed `taps`
* Adds `--force` flag to force Brew backups even if errors are present in `brew doctor`